### PR TITLE
Sentry fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Skedge",
   "displayName": "Skedge",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "your registration assistant by students, for students",
   "author": "Nebula Labs",
   "packageManager": "npm@8.19.2",
@@ -104,7 +104,8 @@
     "host_permissions": [
       "https://utdallas.collegescheduler.com/*",
       "https://www.ratemyprofessors.com/*",
-      "https://trends.utdnebula.com/*"
+      "https://trends.utdnebula.com/*",
+      "https://*.sentry.io/*"
     ],
     "browser_specific_settings": {
       "gecko": {

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -8,9 +8,13 @@ import React from 'react';
 import Index from '~/app';
 import { neededOrigins } from '~data/config';
 
+const realBrowser = process.env.PLASMO_BROWSER === 'chrome' ? chrome : browser;
+
 //Same as in src/tabs/permissions.tsx
 Sentry.init({
-  dsn: 'https://c7a0478d8f145e3c8f690bf523d8b9cd@o4504918397353984.ingest.us.sentry.io/4509386315071488',
+  dsn:
+    process.env.NODE_ENV === 'production' &&
+    'https://c7a0478d8f145e3c8f690bf523d8b9cd@o4504918397353984.ingest.us.sentry.io/4509386315071488',
 
   // Add optional integrations for additional features
   integrations: [
@@ -33,9 +37,11 @@ Sentry.init({
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
+
+  release: realBrowser?.runtime?.getManifest?.().version ?? 'development',
+  environment: process.env.NODE_ENV ?? 'development',
 });
 
-const realBrowser = process.env.PLASMO_BROWSER === 'chrome' ? chrome : browser;
 async function checkPermissions() {
   const currentPermissions: { origins?: string[] } =
     await realBrowser.permissions.getAll();


### PR DESCRIPTION
Wasn't seeing anything on Sentry for Skedge. Mostly just had to disable the "Filter out errors known to be caused by browser extensions" setting but these fixes also help disable Sentry in development and avoid a Sentry warning in the console.