### PR TITLE
Only send Sentry errors on prod

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -26,6 +26,9 @@ jobs:
 
       - name: Install packages
         run: npm ci
+      
+      - name: Set up test environment file
+        run: echo "PLASMO_PUBLIC_SENTRY_DSN=https://c7a0478d8f145e3c8f690bf523d8b9cd@o4504918397353984.ingest.us.sentry.io/4509386315071488" > .env.local
 
       - name: Build and package extension
         run: npm run build:chrome && npm run build:firefox

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install packages
         run: npm ci
-      
+
       - name: Set up test environment file
         run: echo "PLASMO_PUBLIC_SENTRY_DSN=https://c7a0478d8f145e3c8f690bf523d8b9cd@o4504918397353984.ingest.us.sentry.io/4509386315071488" > .env.local
 

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -10,8 +10,7 @@ const realBrowser = process.env.PLASMO_BROWSER === 'chrome' ? chrome : browser;
 
 //Same as in src/tabs/permissions.tsx
 Sentry.init({
-  dsn:
-    process.env.PLASMO_PUBLIC_SENTRY_DSN,
+  dsn: process.env.PLASMO_PUBLIC_SENTRY_DSN,
 
   // Add optional integrations for additional features
   integrations: [

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -11,8 +11,7 @@ const realBrowser = process.env.PLASMO_BROWSER === 'chrome' ? chrome : browser;
 //Same as in src/tabs/permissions.tsx
 Sentry.init({
   dsn:
-    process.env.NODE_ENV === 'production' &&
-    'https://c7a0478d8f145e3c8f690bf523d8b9cd@o4504918397353984.ingest.us.sentry.io/4509386315071488',
+    process.env.PLASMO_PUBLIC_SENTRY_DSN,
 
   // Add optional integrations for additional features
   integrations: [

--- a/src/tabs/permissions.tsx
+++ b/src/tabs/permissions.tsx
@@ -6,7 +6,7 @@ import React, { useState } from 'react';
 
 //Same as in src/popup.tsx
 Sentry.init({
-  dsn: 'https://c7a0478d8f145e3c8f690bf523d8b9cd@o4504918397353984.ingest.us.sentry.io/4509386315071488',
+  dsn: process.env.PLASMO_PUBLIC_SENTRY_DSN,
 
   // Add optional integrations for additional features
   integrations: [


### PR DESCRIPTION
Resolves #110 

Turns out this wasn't too hard, we can just put the Sentry DSN in an environment variable and only create the `.env.local` file in the GitHub action that deploys the extension. That way no one in development ever has Sentry listening to their errors, and production always does.

The only thing to note about this is that if one wants to manually submit the extension to one of the web stores, they must make their own `.env.local` file with the `PLASMO_PUBLIC_SENTRY_DSN` variable.